### PR TITLE
made glance_manage and keystone_manage work with havana and kept them backwards compatible

### DIFF
--- a/glance_manage
+++ b/glance_manage
@@ -24,15 +24,11 @@ EXAMPLES = '''
 glance_manage: action=dbsync
 '''
 
-try:
-    import glance.db.sqlalchemy.api
-    # this is necessary starting from havana release due to bug 885529
-    # https://bugs.launchpad.net/glance/+bug/885529
-    from glance.openstack.common import gettextutils
-    gettextutils.install('glance')
-except:
-    # this is not havana release
-    pass
+# this is necessary starting from havana release due to bug 885529
+# https://bugs.launchpad.net/glance/+bug/885529
+from glance.openstack.common import gettextutils
+gettextutils.install('glance')
+import glance.db.sqlalchemy.api
 
 try:
     from glance.db.sqlalchemy import migration

--- a/keystone_manage
+++ b/keystone_manage
@@ -31,8 +31,8 @@ try:
     # https://bugs.launchpad.net/glance/+bug/885529
     from keystone.openstack.common import gettextutils
     gettextutils.install('keystone')
-except:
-    # this is not havana release
+except AttributeError:
+    # this is not havana
     pass
 
 try:
@@ -55,10 +55,10 @@ def will_db_change(conf):
     current_version = migration.db_version()
 
     # in havana the method _find_migrate_repo has been renamed to find_migrate_repo
-    if hasattr(migration, "find_migrate_repo"):
-      repo_path = migration.find_migrate_repo()
-    else:
-      repo_path = migration._find_migrate_repo()
+    try:
+        repo_path = migration.find_migrate_repo()
+    except AttributeError:
+        repo_path = migration._find_migrate_repo()
     repo_version = versioning_api.repository.Repository(repo_path).latest
     return current_version != repo_version
 


### PR DESCRIPTION
Hi lorin

I've made my changes to glance_manage and keystone_manage backwards compatible and tested them with grizzly. So they work with havana and grizzly now.

Cheers,
Mauro
