### PR TITLE
Bugfix: Updating security group rules causes rules of other security rules to be deleted

### DIFF
--- a/neutron_sec_group
+++ b/neutron_sec_group
@@ -211,8 +211,7 @@ def _update_sg(module, network_client, sg):
     # Security rules group update
     # We keep things simple: first remove all rules, then insert the new
     # rules. Not terribly efficient, but easy to implement.
-    existing_rules = network_client.list_security_group_rules(sg['id'])
-    existing_rules = existing_rules['security_group_rules']
+    existing_rules = sg['security_group_rules']
 
     for rule in existing_rules:
         network_client.delete_security_group_rule(rule['id'])


### PR DESCRIPTION
This bug was caused by an incorrect use of the neutron pythonclient.

Confusion was caused by a shortcoming in the python-neutronclient. A bug has been opened:
https://bugs.launchpad.net/python-neutronclient/+bug/1359230
