### PR TITLE
neutron_sec_group: Avoid calling keystone.tenants.list() where possible

### DIFF
--- a/neutron_sec_group
+++ b/neutron_sec_group
@@ -376,6 +376,11 @@ def _get_tenant_id(module, identity_client):
     else:
         tenant_name = module.params['tenant_name']
 
+    # If the user is not an admin, they cannot list all tenants. If they are
+    # updating groups in their own tenency we can avoid the need to do that.
+    if identity_client.tenant_name == tenant_name:
+        return identity_client.tenant_id
+
     tenant = _get_tenant(identity_client, tenant_name)
 
     return tenant.id
@@ -388,6 +393,7 @@ def _get_tenant(identity_client, tenant_name):
     :param tenant_name: name of the tenant.
     :return: tenant for which the name was given.
     """
+    # This requires admin permissions.
     tenants = identity_client.tenants.list()
     tenant = next((t for t in tenants if t.name == tenant_name), None)
     if not tenant:


### PR DESCRIPTION
I was getting this error trying to update security groups from a
playbook which previously worked:

    msg: Error: You are not authorized to perform the requested action,
    admin_required. (HTTP 403)

It seems that a recent change in Icehouse means that calling
tenants.list() is now a privileged operation.

If the user is updating groups in their login tenancy we don't need to
call tenants.list() just to get the tenant ID. We can get it from the
session. This commit makes my playbook work again without requiring me
to be an admin.