### PR TITLE
bugfix: was using the first available FIP regardless of tenant

### DIFF
--- a/neutron_floating_ip
+++ b/neutron_floating_ip
@@ -178,6 +178,11 @@ def _get_floating_ip(module, neutron, fixed_ip_address):
         return None, None
     return ips['floatingips'][0]['id'], ips['floatingips'][0]['floating_ip_address']
 
+def _get_tenant_id(module):
+    tenants = _get_ksclient(module, {}).tenants.list()
+    tenant = next((t for t in tenants if t.name == module.params.get('login_tenant_name')), None)
+    return tenant.id
+
 def _assign_floating_ip(neutron, module, port_id, net_id):
     kwargs = {
             'floating_network_id': net_id
@@ -187,7 +192,8 @@ def _assign_floating_ip(neutron, module, port_id, net_id):
     except Exception as e:
         module.fail_json(msg = "error in fetching the floatingips's %s" % e.message)
 
-    fip = next((fip for fip in ips['floatingips'] if fip['port_id'] is None), None)
+    tenant_id = _get_tenant_id(module)
+    fip = next((fip for fip in ips['floatingips'] if fip['port_id'] is None and fip['tenant_id'] == tenant_id), None)
 
     if fip is None:
         _create_floating_ip(neutron, module, port_id, net_id)


### PR DESCRIPTION
The first available FIP was being chosen without checking if the FIP was associated with a different tenant.  The problem is reproducable by authenticating as a user that has the admin role in multiple tenants with multiple available FIP's.

The result was a failed ansible run with the following error message:
```
  There was an error in updating the floating ip address: Bad floatingip
  request: Port 59fcedb5-187e-45ed-9ea3-df02c1530e76 is associated with
  a different tenant than Floating IP 0902d117-89e2-40d6-802d-b29f5273289b
  and therefore cannot be bound.
```

![screen shot 2015-09-17 at 4 16 28 pm](https://cloud.githubusercontent.com/assets/693822/9949101/a2962252-5d5e-11e5-976a-1f0d30f3c5c6.png)
