### PR TITLE
Fix ImportError in "keystone_manage: action=dbsync"

### DIFF
--- a/keystone_manage
+++ b/keystone_manage
@@ -31,7 +31,7 @@ try:
     # https://bugs.launchpad.net/glance/+bug/885529
     from keystone.openstack.common import gettextutils
     gettextutils.install('keystone')
-except AttributeError:
+except ImportError:
     # this is not havana
     pass
 


### PR DESCRIPTION
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_lKCJSO/ansible_module_keystone_manage.py", line 32, in <module>
    from keystone.openstack.common import gettextutils
ImportError: No module named openstack.common